### PR TITLE
Add namespaces, ingress and install/uninstall scripts

### DIFF
--- a/manifest/ingress.yaml
+++ b/manifest/ingress.yaml
@@ -1,0 +1,60 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: coolstat-ingress-subpath
+  namespace: coolstat
+  annotations:
+    acme.cert-manager.io/http01-edit-in-place: "true"
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: '43200'
+    nginx.ingress.kubernetes.io/proxy-read-timeout: '43200'
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: '43200'
+    nginx.ingress.kubernetes.io/client-max-body-size: "100G"
+    nginx.ingress.kubernetes.io/proxy-body-size: "100G"
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: fluor.ii.uam.es
+    http:
+      paths:
+      - path: /coolstat(/|$)(.*)
+        pathType: ImplementationSpecific
+        backend:
+          service: 
+            name: streamlit-service
+            port: 
+              number: 8501
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: coolstat-ingress
+  namespace: coolstat
+  annotations:
+    cert-manager.io/cluster-issuer: cert-manager-webhook-duckdns-production
+    acme.cert-manager.io/http01-edit-in-place: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: '43200'
+    nginx.ingress.kubernetes.io/proxy-read-timeout: '43200'
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: '43200'
+    nginx.ingress.kubernetes.io/client-max-body-size: "100G"
+    nginx.ingress.kubernetes.io/proxy-body-size: "100G"
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: coolstat.fluor-hpcn.duckdns.org
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service: 
+            name: streamlit-service
+            port: 
+              number: 8501
+  tls:
+  - hosts:
+    - coolstat.fluor-hpcn.duckdns.org
+    secretName: coolstat-cert

--- a/manifest/install.sh
+++ b/manifest/install.sh
@@ -1,0 +1,6 @@
+kubectl create ns coolstat
+kubectl apply -f postgres-deployment.yaml 
+kubectl apply -f postgres-service.yaml
+kubectl apply -f streamlit-deployment.yaml 
+kubectl apply -f streamlit-service.yaml 
+kubectl apply -f ingress.yaml

--- a/manifest/postgres-deployment.yaml
+++ b/manifest/postgres-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: postgres-db
+  namespace: coolstat
 spec:
   replicas: 1
   selector:

--- a/manifest/postgres-service.yaml
+++ b/manifest/postgres-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: postgres-service
+  namespace: coolstat
 spec:
   type: ClusterIP
   selector:

--- a/manifest/streamlit-deployment.yaml
+++ b/manifest/streamlit-deployment.yaml
@@ -2,8 +2,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: streamlit-app
+  namespace: coolstat
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: streamlit-app

--- a/manifest/streamlit-service.yaml
+++ b/manifest/streamlit-service.yaml
@@ -2,11 +2,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: streamlit-service
+  namespace: coolstat
 spec:
-  type: NodePort
+  type: ClusterIP
   selector:
     app: streamlit-app
   ports:
   - port: 8501
     targetPort: 8501
-    nodePort: 30001 # Es el puerto que se expondrá en el nodo del clúster para acceder a la app Streamlit

--- a/manifest/uninstall.sh
+++ b/manifest/uninstall.sh
@@ -1,0 +1,6 @@
+kubectl delete -f postgres-deployment.yaml 
+kubectl delete -f postgres-service.yaml
+kubectl delete -f streamlit-deployment.yaml 
+kubectl delete -f streamlit-service.yaml 
+kubectl delete -f ingress.yaml
+kubectl delete ns coolstat


### PR DESCRIPTION
- Added to all k8s objects the namespace `coolstat`.
- Added an ingress to be compatible with our setup.
- Change svc from NodePort to ClusterIP for security reasons.
- Added scripts for easy management.